### PR TITLE
Replay instructions on invalid key, fix recording actions

### DIFF
--- a/src/VoicemailDirectory.WebApi/Controllers/IncomingCallController.cs
+++ b/src/VoicemailDirectory.WebApi/Controllers/IncomingCallController.cs
@@ -14,7 +14,7 @@ public class IncomingCallController : TwilioController
 
     public IncomingCallController(
         ILogger<IncomingCallController> logger,
-        IOptions<VoicemailOptions> voicemailOptions
+        IOptionsSnapshot<VoicemailOptions> voicemailOptions
     )
     {
         _logger = logger;

--- a/src/VoicemailDirectory.WebApi/Services/FileService.cs
+++ b/src/VoicemailDirectory.WebApi/Services/FileService.cs
@@ -14,9 +14,11 @@ public class FileService
     public async Task DownloadRecording(string recordingUrl, string recordingSid)
     {
         using HttpResponseMessage response = await _httpClient.GetAsync($"{recordingUrl}.mp3");
-        await using Stream recordingFileStream = await response.Content.ReadAsStreamAsync();
-        await using var fs = new FileStream($"{_rootVoicemailPath}/{Constants.New}_{recordingSid}.mp3",
-            FileMode.CreateNew);
+        response.EnsureSuccessStatusCode();
+        await using var fs = new FileStream(
+            $"{_rootVoicemailPath}/{Constants.New}_{recordingSid}.mp3",
+            FileMode.CreateNew
+        );
         await response.Content.CopyToAsync(fs);
     }
 


### PR DESCRIPTION
Instead of replaying the message and then the instructions, we should replay the instructions only when an invalid key is pressed.

Apparently, the action-callback does not ensure that the recording is ready, so the action callback now only says goodbye, and the status callback is used to properly save the recording file.